### PR TITLE
Use image_transport and advertise SetCameraInfo service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(catkin REQUIRED COMPONENTS
         roscpp
         sensor_msgs
         std_msgs
+        camera_calibration_parsers
 )
 
 find_package(Boost REQUIRED COMPONENTS system)
@@ -135,7 +136,7 @@ generate_dynamic_reconfigure_options(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES cone_filter
-  CATKIN_DEPENDS cv_bridge dynamic_reconfigure image_transport roscpp sensor_msgs std_msgs
+  CATKIN_DEPENDS cv_bridge dynamic_reconfigure image_transport roscpp sensor_msgs std_msgs camera_calibration_parsers
   
   #  DEPENDS
 )

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Linux [ROS C++ Node](https://wiki.ros.org/peak_cam) that wraps the driver API for IDS vision cameras using IDS peak software. Tested on Ubuntu 18.04 LTS and 20.04 LTS.
 
+Supports the set_camera_info service used by the ROS [camera_calibration](http://wiki.ros.org/camera_calibration) package.
+
 ## How to run
 
 ### Before running the code
@@ -15,7 +17,7 @@ A Linux [ROS C++ Node](https://wiki.ros.org/peak_cam) that wraps the driver API 
 1. (Update camera firmware if needed: `ids_deviceupdate -s *<last-four-digits-serialnumber> -U --guf <path-to-guf-file>`)
 
 #### Configuration for GigE cameras
-1. Enable jumboframes for the ethernet interface(s) (e.g., `eth0`) used for your camera(s): `ip link set dev eth0 mtu 9000`
+1. Enable jumboframes for the ethernet interface(s) (e.g., `eth0`) used for your camera(s) by setting MTU to 9000 in your network manager, by editing `/etc/network/interfaces` or non-permanent using `ip link set dev eth0 mtu 9000`
 1. Increase receive buffer size [as recommended in the IDS manual](https://en.ids-imaging.com/manuals/ids-peak/ids-peak-user-manual/1.3.1/en/operate-gige-hints-linux.html): `sudo /usr/local/scripts/ids_set_receive_buffer_size.sh`
 1. Make sure to adjust `DeviceLinkThroughputLimit` in the `.yaml` configuration file according to your desired framerate and available hardware (employing separate network interfaces may be beneficial)
 
@@ -77,7 +79,7 @@ The cameras can also be triggered by the pulses of external devices such as a li
     TriggerSource: "Line0"
     ```
 
-Copyright (c) 2020, Sherif Nekkah, Felix Keppler (Fraunhofer IVI) and Contributors 
+Copyright (c) 2020, Sherif Nekkah, Felix Keppler (Fraunhofer IVI), Johannes Schäfer (Fraunhofer IVI) and Contributors 
 
 All rights reserved.
 

--- a/cfg/PeakCam.cfg
+++ b/cfg/PeakCam.cfg
@@ -39,7 +39,9 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 gen.add("camera_topic", str_t, 0, "name of the camera topic", "/camera/image_raw")
-
+gen.add("camera_name", str_t, 0, "unique camera name for calibration and set_camera_info service", "peak_camera")
+gen.add("frame_name", str_t, 0, "coordinate frame of the imager stored in image header enabling 3D coordinate transforms in tf", "peak_camera")
+gen.add("camera_intrinsics_file", str_t, 0,"Calibration file", "")
 gen.add("GainAuto", str_t, 0, "", "Off")
 gen.add("GainSelector", str_t, 0, "", "")
 gen.add("ExposureAuto", str_t, 0, "", "Off")

--- a/launch/params/peak_cam_params.yaml
+++ b/launch/params/peak_cam_params.yaml
@@ -8,6 +8,12 @@
 
 camera_topic: image_raw
 
+# unique camera name for calibration and set_camera_info service
+camera_name: peak_camera
+
+# coordinate frame of the imager stored in image header enabling 3D coordinate transforms in tf
+frame_name: peak_camera
+
 # choose which device to enter by entering its serial number here
 # if you dont know it, run this node once and all serial nodes should be printed out
 selectedDevice: "0000000000"

--- a/launch/peak_cam_node.launch
+++ b/launch/peak_cam_node.launch
@@ -1,8 +1,10 @@
 <launch>
     <arg name="node_name" default="peak_cam_node" />
     <arg name="config" default="$(find peak_cam)/launch/params/peak_cam_params.yaml" />
+    <arg name="camera_intrinsics_file" default="$(env HOME)/.ros/camera_info/$(arg node_name).yaml"/> <!-- default: ~/.ros/camera_info/<node_name>.yaml-->
 
     <node pkg="peak_cam" type="peak_cam_node" name="$(arg node_name)" output="screen">
         <rosparam command="load" file="$(arg config)"/>
+        <param name="camera_intrinsics_file" type="string" value="$(arg camera_intrinsics_file)"/>
     </node>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -39,18 +39,21 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>camera_calibration_parsers</build_depend>
   <build_export_depend>cv_bridge</build_export_depend>
   <build_export_depend>dynamic_reconfigure</build_export_depend>
   <build_export_depend>image_transport</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>camera_calibration_parsers</build_export_depend>
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>dynamic_reconfigure</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>camera_calibration_parsers</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/peak_cam.hpp
+++ b/src/peak_cam.hpp
@@ -47,6 +47,10 @@
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/image_encodings.h>
 #include <dynamic_reconfigure/server.h>
+#include <image_transport/image_transport.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/SetCameraInfo.h>
+#include <camera_calibration_parsers/parse.h>
 
 //OpenCV Headers
 #include <opencv2/opencv.hpp>
@@ -91,8 +95,19 @@ private:
     void openDevice();
     void setDeviceParameters();
     void closeDevice();
+    bool setCamInfo(sensor_msgs::SetCameraInfo::Request& req, sensor_msgs::SetCameraInfo::Response& rsp);
+    bool saveIntrinsicsFile();
 
-    ros::Publisher image_publisher;
+    image_transport::CameraPublisher pub_image_transport;
+    sensor_msgs::Image ros_image_;
+    sensor_msgs::CameraInfo ros_cam_info_;
+    unsigned int ros_frame_count_;
+    std::string camera_topic_;
+    std::string cam_name_;
+    std::string frame_name_;
+    std::string cam_intr_filename_;
+
+    ros::ServiceServer set_cam_info_srv_;
 
     dynamic_reconfigure::Server<Config> server;
     dynamic_reconfigure::Server<Config>::CallbackType f;

--- a/src/peak_cam_node.cpp
+++ b/src/peak_cam_node.cpp
@@ -70,7 +70,6 @@ int main(int argc, char **argv)
   
     // Seperating acquisition Loop on particular thread
     std::thread acquisitionThread(&peak_cam::Peak_Cam::acquisitionLoop, &peak_Cam);
-    acquisitionThread.join();
 
     while (ros::ok())
     {
@@ -80,6 +79,8 @@ int main(int argc, char **argv)
         if (!*acquisitionLoop_running_ptr)
             return EXIT_SUCCESS;
     }
+
+    acquisitionThread.join();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- Images are now transported using [ROS image_transport](http://wiki.ros.org/image_transport) including [sensor_msgs/CameraInfo](http://docs.ros.org/en/api/sensor_msgs/html/msg/CameraInfo.html) in analogy to [ueye_cam](https://wiki.ros.org/ueye_cam)
- SetCameraInfo service is advertised in order to directly commit calibration data acquired using [camer_calibration](wiki.ros.org/camera_calibration)